### PR TITLE
[mobile/drinkpage]음료 관리 현황 페이지 등록번호가 2줄이 되는 현상 수정

### DIFF
--- a/mobile/hango/app/src/main/res/layout/activity_drink_main.xml
+++ b/mobile/hango/app/src/main/res/layout/activity_drink_main.xml
@@ -76,31 +76,28 @@
             android:layout_marginRight="10sp"
             android:layout_marginTop = "10sp"
             android:textAppearance="@style/TextAppearance.AppCompat.Large" />
-        <LinearLayout
+        <RelativeLayout
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
+            android:layout_height="wrap_content">
             <TextView
                 android:id="@+id/tv_drink_page_vending_serial_number"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="10sp"
-                android:layout_marginRight="10sp"
+                android:layout_marginRight="60sp"
                 android:layout_marginTop = "10sp"
+                android:ellipsize="end"
+                android:singleLine="true"
                 android:textAppearance="@style/TextAppearance.AppCompat.Large" />
-            <View
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                android:layout_weight="1"/>
             <ImageView
                 android:id = "@+id/iv_drink_main_guide"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_gravity="right|center_vertical"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 android:layout_marginRight="10dp"
-
+                android:layout_alignParentRight="true"
                 android:background="@drawable/ic_info"/>
-        </LinearLayout>
+        </RelativeLayout>
+
     </LinearLayout>
 
     <android.support.v4.widget.SwipeRefreshLayout


### PR DESCRIPTION
등록번호가 Layout를 넘어갈 경우 두줄로 바뀌어 일정 이상 길어지면 ...
으로 표시되도록 수정

Signed-off-by: KiSuSong <8345783@naver.com>

## 제목
음료 관리 현황 페이지 등록번호가 2줄이 되는 현상 수정

## 작업 내용
음료 관리 현황 페이지 등록번호가 Layout보다 길어지는 부분은 ...으로 표시하도록 함




