### PR TITLE
[mobile/mainpage]자판기가 없을때 사용되는 Adapter 클릭시 앱이 종료되는 버그 수정

### DIFF
--- a/mobile/hango/app/src/main/java/com/hango/hangoactivity/MainActivity.java
+++ b/mobile/hango/app/src/main/java/com/hango/hangoactivity/MainActivity.java
@@ -160,19 +160,22 @@ public class MainActivity extends AppCompatActivity {
         vendingDataParser(vendingAdapter);
 
         //각 자판기 Item Click Listener
+
         vendingListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                // 자판기 정보 Item View Type
+
 
                 VendingData vendingData = (VendingData) vendingAdapter.getItem(position);
 
-                
-                Intent intent = new Intent(getApplicationContext(),DrinkMainActivity.class);
-                intent.putExtra("name",vendingData.getVendingName());
-                intent.putExtra("description",vendingData.getVendingDescription());
+
+                Intent intent = new Intent(getApplicationContext(), DrinkMainActivity.class);
+                intent.putExtra("name", vendingData.getVendingName());
+                intent.putExtra("description", vendingData.getVendingDescription());
                 int fullSize = vendingData.getVendingFullsize();
-                intent.putExtra("fullSize",fullSize);
-                intent.putExtra("serialNumber",vendingData.getVendingSerialNumber());
+                intent.putExtra("fullSize", fullSize);
+                intent.putExtra("serialNumber", vendingData.getVendingSerialNumber());
                 startActivity(intent);
 
             }

--- a/mobile/hango/app/src/main/java/com/hango/hangoactivity/VendingListAdapter.java
+++ b/mobile/hango/app/src/main/java/com/hango/hangoactivity/VendingListAdapter.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
 import android.view.LayoutInflater;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
@@ -137,6 +138,14 @@ public class VendingListAdapter extends BaseAdapter implements Filterable {
                     break;
                 case ITEM_VIEW_TYPE_EMPTY_VENDING:
                     convertView = inflater.inflate(R.layout.empty_vending, parent, false);
+                    //클릭 비활성화
+                    convertView.setOnTouchListener(new View.OnTouchListener() {
+
+                        @Override
+                        public boolean onTouch(View v, MotionEvent event) {
+                            return true;
+
+                        }});
                     break;
             }
 


### PR DESCRIPTION
Signed-off-by: KiSuSong <8345783@naver.com>

## 제목
자판기가 없을때 사용되는 Adapter 클릭시 앱이 종료되는 버그 수정

## 작업 내용
자판기가 없을때 사용되는 Adapter 클릭시 앱이 종료되는 버그 수정



